### PR TITLE
added ipykernel &  pip to (hopefully allow support for ipython...)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ RUN apt update -y && \
   make \
   curl
 
-RUN conda install -c conda-forge -y -q cookiecutter
+RUN conda install -c conda-forge -y -q \
+  cookiecutter \
+  ipykernel \
+  pip
+  
 
 RUN curl -sSL https://install.python-poetry.org | python3 -
 


### PR DESCRIPTION
So this does give access to iPython, but when I try to launch the interactive iPython terminal with `Shift` + `Enter` I still get this prompt:
<img width="521" alt="Screen Shot 2022-02-11 at 7 37 33 PM" src="https://user-images.githubusercontent.com/6865016/153695287-c3eb33d2-a0e4-472e-8364-90fea1b728cb.png">

Then if I click through on "Change kernel" I get these options, from which I can select `base(Python 3.9.5 /opt/conda/bin/python)` and then it works.

<img width="843" alt="Screen Shot 2022-02-11 at 7 37 37 PM" src="https://user-images.githubusercontent.com/6865016/153695324-00a847e0-1ff7-40fb-8c9b-6556eb1d8c8f.png">

So what would be good is to somehow configure this dev container to start with `base(Python 3.9.5 /opt/conda/bin/python)` as the kernel so users don't have to do this... Wonder if we can set that in `.devcontainer.json`?

